### PR TITLE
Add emotion-tailwind-preflight library

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [styled-map](https://github.com/scf4/styled-map) - Super simple lib to map props to styles
 - [polished](https://github.com/styled-components/polished) - Lightweight set of Sass/Compass-style mixins/helpers for writing styles in JavaScript.
 - [styled-conditions](https://github.com/karolisgrinkevicius/styled-conditions) - Ultra-lightweight flag utility to conditionally apply css depending on React props.
+- [emotion-tailwind-preflight](https://github.com/flogy/emotion-tailwind-preflight) - Merge the shiny TailwindCSS base styles into your CSS-in-JS project
 
 ## Component Libraries
 


### PR DESCRIPTION
Add the [emotion-tailwind-preflight](https://github.com/flogy/emotion-tailwind-preflight) library to the list. With this library developers can use the [TailwindCSS base styles](https://tailwindcss.com/docs/adding-base-styles/) in their emotion projects.